### PR TITLE
Attempt to fix missing newlines

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -214,7 +214,6 @@
 				</label>
 			</footer>
 			<div id="export" v-if="options.show" class="flex flex-col" style="grid-row: 2 / span 2">
-				<textarea class="sr-only" readonly="readonly" ref="exportTextArea"></textarea>
 				<div class="grid grid-cols-1 lg:grid-cols-[300px,2fr] items-center gap-2 lg:gap-8">
 					<label class="uppercase font-medium text-gray-600 text-sm">Ffmpeg path</label>
 					<input

--- a/docs/main.js
+++ b/docs/main.js
@@ -149,16 +149,25 @@ let app = {
 			}
 		},
 		copyCommand() {
-			let textArea = this.$refs.exportTextArea;
+			let textArea = document.createElement('textarea');
 			textArea.value = exportWinCmd(this.clips, this.options);
+			document.body.appendChild(textArea);
 			textArea.select();
+			let success;
 			try {
 				document.execCommand("copy");
-				alert("The processing commands were successfully copied to your clipboard!");
+				success = true;
 			}
 			catch (ex) {
 				console.error(ex);
-				alert("There was an error copying the processing commands...")
+				success = false;
+			}
+			document.body.removeChild(textArea);
+			if (success) {
+				alert("The processing commands were successfully copied to your clipboard!");
+			}
+			else {
+				alert("There was an error copying the processing commands...");
 			}
 		},
 	},


### PR DESCRIPTION
In (Chrome) Edge when the processing commands are copied all the newlines have disappeared, this appears to happen when the textarea is hidden. When I remove the `sr-only` class the newlines are fine. Workaround by creating a temporary textarea element instead.