### PR TITLE
Add option to cleanup files

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -236,6 +236,13 @@
 						class="focus:ring-indigo-600 focus:ring-offset-indigo-600 focus:border-indigo-600"
 						@input="saveOption('filename')"
 					/>
+					<label class="uppercase font-medium text-gray-600 text-sm mt-4 lg:mt-0">Cleanup temp files</label>
+					<input
+						type="checkbox"
+						v-model="options.cleanup"
+						class="focus:ring-indigo-600 focus:ring-offset-indigo-600 focus:border-indigo-600"
+						@input="saveOption('cleanup')"
+					/>
 				</div>
 				<div
 					class="flex flex-col justify-between lg:items-end space-y-4 space-x-0 lg:space-y-0 lg:flex-row lg:space-x-4 mt-auto lg:mt-0 py-8"

--- a/docs/main.js
+++ b/docs/main.js
@@ -32,6 +32,7 @@ let app = {
 				filename: "output.mp4",
 				ffmpeg: "ffmpeg.exe",
 				codec: "-vcodec h264 -acodec copy",
+				cleanup: true,
 			},
 		};
 	},
@@ -144,6 +145,7 @@ let app = {
 				this.options.ffmpeg = localStorage.getItem("PCE/" + "ffmpeg") ?? this.options.ffmpeg;
 				this.options.codec = localStorage.getItem("PCE/" + "codec") ?? this.options.codec;
 				this.options.filename = localStorage.getItem("PCE/" + "filename") ?? this.options.filename;
+				this.options.cleanup = localStorage.getItem("PCE/" + "cleanup") ?? this.options.cleanup;
 			}
 			catch (ex) {
 				console.error(ex);
@@ -223,10 +225,12 @@ function exportWinCmd(clips, options) {
 		cmd += `ECHO file 'part${i}.mp4'>>"${tmp}\\parts.txt"\n`;
 	}
 	cmd += `${ffmpeg} -f concat -i "${tmp}\\parts.txt" -c copy ${filename}<NUL\n`;
-	cmd += "DEL /Q";
-	for (let i = 0; i < clips.length; i += 1) {
-		cmd += ` "${tmp}\\part${i}.mp4"`;
+	if (options.cleanup) {
+		cmd += "DEL /Q";
+		for (let i = 0; i < clips.length; i += 1) {
+			cmd += ` "${tmp}\\part${i}.mp4"`;
+		}
+		cmd += ` "${tmp}\\parts.txt"\nRMDIR ${tmp}\n`;
 	}
-	cmd += ` "${tmp}\\parts.txt"\nRMDIR ${tmp}\n`;
 	return cmd;
 }


### PR DESCRIPTION
Leaving the temp files around enables the user to choose which cuts to use and even reorder if desired and rerender without the expensive reencoding.