### PR TITLE
Fix pause before deletion

### DIFF
--- a/docs/helpers.js
+++ b/docs/helpers.js
@@ -113,12 +113,11 @@ export function exportWinCmd(clips, options) {
 	cmd += `${ffmpeg} -f concat -i "${tmp}\\parts.txt" -c copy ${fileName}<NUL\n`;
 	if (options.cleanup) {
 		cmd += "echo Pausing before deleting temporary files, ctrl-C to abort now\n"
-		cmd += "pause\n"
-		cmd += "DEL /Q";
+		cmd += "pause && DEL /Q"
 		for (let i = 0; i < clips.length; i += 1) {
 			cmd += ` "${tmp}\\part${i}.mp4"`;
 		}
-		cmd += ` "${tmp}\\parts.txt"\nRMDIR ${tmp}\n`;
+		cmd += ` "${tmp}\\parts.txt" && RMDIR ${tmp}\n`;
 	}
 	return cmd;
 }


### PR DESCRIPTION
Every command executed after a pause on a new line appears to be forgotten.
Instead put the commands on a single line to make it work.